### PR TITLE
Relaxed resourcet version constraint

### DIFF
--- a/stm-conduit.cabal
+++ b/stm-conduit.cabal
@@ -1,5 +1,5 @@
 Name:                stm-conduit
-Version:             0.4.2
+Version:             0.4.3
 Synopsis:            Introduces conduits to channels, and promotes using
                      conduits concurrently.
 Description:         Provides two simple conduit wrappers around STM
@@ -25,7 +25,7 @@ Library
       , stm          == 2.4.*
       , stm-chans    == 1.3.*
       , conduit      == 0.5.*
-      , resourcet    == 0.3.*
+      , resourcet    >= 0.3 && < 0.5
 
     ghc-options: -Wall -fwarn-tabs -fwarn-unused-imports
 


### PR DESCRIPTION
Now compiles on GHC 7.6 with the newest versions of the packages.
