### PR TITLE
Allow directory 1.1

### DIFF
--- a/stm-conduit.cabal
+++ b/stm-conduit.cabal
@@ -29,7 +29,7 @@ Library
       , cereal         >= 0.4.0.1
       , cereal-conduit >= 0.7.2
       , conduit        == 1.0.*
-      , directory      >= 1.2
+      , directory      >= 1.1
       , resourcet      >= 0.3 && < 0.5
       , async          >= 2.0.1
       , monad-control  >= 0.3.2


### PR DESCRIPTION
GHC 7.4 ships with this version of directory. No code changes required, just a cabal tweak.
