### PR TITLE
Add an 'entangledPair' convenience function

### DIFF
--- a/Data/Conduit/TQueue.hs
+++ b/Data/Conduit/TQueue.hs
@@ -51,7 +51,6 @@ module Data.Conduit.TQueue
   , module Control.Concurrent.STM.TQueue
   ) where
 
-import Control.Arrow ((&&&))
 import Control.Concurrent.STM
 import Control.Concurrent.STM.TQueue
 import Control.Concurrent.STM.TBMQueue


### PR DESCRIPTION
The main purpose for having this function is to allow creating a twinned source/sink on top of a 'TBQueue', but without allowing any other code to interact with this queue.
