### PR TITLE
Fix GHC 7.4 build by removing unused LambdaCase pragma

### DIFF
--- a/Data/Conduit/Async/Composition.hs
+++ b/Data/Conduit/Async/Composition.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}


### PR DESCRIPTION
I revised the current version here: https://hackage.haskell.org/package/stm-conduit-2.6.0/revisions/
