### PR TITLE
Fix possible threads leak inside Data.Conduit.Async functions.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+3.1
+--
+* Data.Conduit.Async - fix possible threads leak. Add documentation.
+
 3.0
 ---
 * Data.Conduit.mergeSources - fixed bug when input Sources were not


### PR DESCRIPTION
Worker threads are registered withing a monad resource block.
So now they will be terminated even in case of the early termination
due to the downstream close or an asynchronous exceptions.
